### PR TITLE
Revert to tracking job mem max internally

### DIFF
--- a/backend/backend_ozstar.py
+++ b/backend/backend_ozstar.py
@@ -181,7 +181,6 @@ class Backend(BackendBase):
         self.telegraf_data = telegraf_data
 
     def update_mem_data(self):
-        # Query only RSS measurements
         influx_result = self.query_influx_memory()
 
         mem_data = {}
@@ -201,14 +200,12 @@ class Backend(BackendBase):
                 if job_id not in mem_data:
                     mem_data[job_id] = {"mem": {}, "memMax": 0}
 
-                # Process only RSS measurements
-                if measurement == "RSS":
+                if measurement == "VMSize":
                     jobs_with_stats.append(job_id)
                     node = record["host"]
                     mem = math.ceil(record.get_value() / KB)
                     mem_data[job_id]["mem"][node] = mem
 
-                    # Track the maximum RSS value seen for this job
                     if job_id not in self.mem_max:
                         self.mem_max[job_id] = mem
                     else:
@@ -230,11 +227,11 @@ class Backend(BackendBase):
         return result
 
     def query_influx_memory(self):
-        self.log.info("Querying Influx: memory (RSS only)")
-        # Query only RSS measurements
+        self.log.info("Querying Influx: memory")
+        # Query only VMSize measurements
         query = f'from(bucket:"{influx_config.BUCKET_MEM}")\
         |> range(start: -90s)\
-        |> filter(fn: (r) => r["_measurement"] == "RSS")\
+        |> filter(fn: (r) => r["_measurement"] == "VMSize")\
         |> last()\
         |> drop(columns: ["_start", "_stop", "_time"])\
         |> group(columns: ["job", "host", "_measurement"])\

--- a/backend/backend_ozstar.py
+++ b/backend/backend_ozstar.py
@@ -181,7 +181,7 @@ class Backend(BackendBase):
         self.telegraf_data = telegraf_data
 
     def update_mem_data(self):
-        # Query both RSS and VMSize measurements in a single call
+        # Query only RSS measurements
         influx_result = self.query_influx_memory()
 
         mem_data = {}
@@ -201,26 +201,20 @@ class Backend(BackendBase):
                 if job_id not in mem_data:
                     mem_data[job_id] = {"mem": {}, "memMax": 0}
 
-                # Process memory measurements
+                # Process only RSS measurements
                 if measurement == "RSS":
-                    # Per-node current memory usage
                     jobs_with_stats.append(job_id)
                     node = record["host"]
                     mem = math.ceil(record.get_value() / KB)
                     mem_data[job_id]["mem"][node] = mem
-                elif measurement == "VMSize":
-                    # Job maximum memory usage across all nodes
-                    mem_max = math.ceil(record.get_value() / KB)
 
-                    # Update the global maximum for this job
+                    # Track the maximum RSS value seen for this job
                     if job_id not in self.mem_max:
-                        self.mem_max[job_id] = mem_max
+                        self.mem_max[job_id] = mem
                     else:
-                        self.mem_max[job_id] = max(self.mem_max[job_id], mem_max)
-
+                        self.mem_max[job_id] = max(self.mem_max[job_id], mem)
                     mem_data[job_id]["memMax"] = self.mem_max[job_id]
 
-        # Turn list of jobs with memory stats into a set to remove duplicates
         jobs_with_stats = set(jobs_with_stats)
 
         self.log.info(
@@ -236,11 +230,11 @@ class Backend(BackendBase):
         return result
 
     def query_influx_memory(self):
-        self.log.info("Querying Influx: memory (RSS and VMSize)")
-        # Query both RSS and VMSize measurements
+        self.log.info("Querying Influx: memory (RSS only)")
+        # Query only RSS measurements
         query = f'from(bucket:"{influx_config.BUCKET_MEM}")\
         |> range(start: -90s)\
-        |> filter(fn: (r) => r["_measurement"] == "RSS" or r["_measurement"] == "VMSize")\
+        |> filter(fn: (r) => r["_measurement"] == "RSS")\
         |> last()\
         |> drop(columns: ["_start", "_stop", "_time"])\
         |> group(columns: ["job", "host", "_measurement"])\


### PR DESCRIPTION
The max memory tracking via VMSize was not accurate. Switch back to tracking it internally. VMSize is now reporting the memory.